### PR TITLE
rustique: update to v0.5.17

### DIFF
--- a/parts/programs/rustique.nix
+++ b/parts/programs/rustique.nix
@@ -12,20 +12,20 @@
         in
         rustPlatform.buildRustPackage (finalAttrs: {
           pname = "Rustique";
-          version = "0.5.11";
+          version = "0.5.17";
 
           src = fetchFromGitHub {
             owner = "Tekunogosu";
             repo = "Rustique";
             rev = "v${finalAttrs.version}";
-            hash = "sha256-CdVZbp3csZ0uQImYBeEhTGLAwL5EA42sefmjylBStMY=";
+            hash = "sha256-YWC1UkXPYfjS6xN3yXW4bQjHbG9ZF/J8fetlJQUfdJM=";
           };
 
           # tries to use clang and /usr/bin/mold, let's just not do that, and
           # use the GNU toolchain from stdenv
           postPatch = "rm -vf .cargo/config.toml";
 
-          cargoHash = "sha256-pIaMiPe3OW6JU5NKUhsVHNsvYvQdIVs1swhWz0wPn08=";
+          cargoHash = "sha256-QnkvqfjY+WR1vXtIgBB7Gm6c8Wkdp1+FnWScJg6ltwY=";
 
           # unstable rust feature path_add_extension
           env.RUSTC_BOOTSTRAP = 1;
@@ -35,7 +35,7 @@
             homepage = "https://github.com/Tekunogosu/Rustique";
             changelog = "https://github.com/Tekunogosu/Rustique/blob/${finalAttrs.src.rev}/changelog.md";
             license = lib.licenses.mit;
-            mainProgram = "Rustique";
+            mainProgram = "rustique-cli";
           };
         });
     };


### PR DESCRIPTION
Updates Rustique to v0.5.17.

The current package version has an incorrect value for the source hash but updating the package just resolves this.